### PR TITLE
Add Custom Pages to System

### DIFF
--- a/app/Http/Controllers/FrontController.php
+++ b/app/Http/Controllers/FrontController.php
@@ -100,6 +100,12 @@ class FrontController extends Controller
     }
     public function page(Request $request,Page $page)
     {
+        $customView = 'front.pages.customPages.' . $page->slug;
+
+        if(view()->exists($customView)) {
+            return view($customView);
+        }         
+
         return view('front.pages.page',compact('page'));
     }
     public function blog(Request $request)

--- a/app/Http/Controllers/FrontController.php
+++ b/app/Http/Controllers/FrontController.php
@@ -105,7 +105,7 @@ class FrontController extends Controller
 
         if(view()->exists($customView)) {
             // If the file exists, return custom page
-            return view($customView);
+            return view($customView,compact('page'));
         }         
 
         return view('front.pages.page',compact('page'));

--- a/app/Http/Controllers/FrontController.php
+++ b/app/Http/Controllers/FrontController.php
@@ -100,9 +100,11 @@ class FrontController extends Controller
     }
     public function page(Request $request,Page $page)
     {
+    
         $customView = 'front.pages.customPages.' . $page->slug;
 
         if(view()->exists($customView)) {
+            // If the file exists, return custom page
             return view($customView);
         }         
 

--- a/resources/views/front/pages/customPages/privacy.blade.php
+++ b/resources/views/front/pages/customPages/privacy.blade.php
@@ -1,18 +1,18 @@
-@extends('layouts.app',['page_title'=>"شروط الاستخدام"])
+@extends('layouts.app',['page_title'=>"سياسة الخصوصية"])
 @section('content')
 <div class="col-12 p-0">
 	<div class=" p-0 container">
 		<div class="col-12 p-2 p-lg-3 row">
 			<div class="col-12 px-2 pt-5 pb-3">
 			    <div class="col-12 p-0 font-4">
-			        <span class="start-head"></span> شروط الاستخدام
+			        <span class="start-head"></span> سياسة الخصوصية
 			    </div>
 			  {{--   <div class="col-12 p-0 mt-1" style="opacity: .7;">
 			        معلومات عنا
 			    </div> --}}
 			</div>
 			<div class="col-12 col-lg-8 p-2">
-				{!!$settings['terms_page']!!}
+				{{-- {!!$settings['privacy_page']!!} --}}
 			</div>
 		</div>
 	</div>

--- a/resources/views/front/pages/customPages/terms.blade.php
+++ b/resources/views/front/pages/customPages/terms.blade.php
@@ -1,18 +1,19 @@
-@extends('layouts.app',['page_title'=>"سياسة الخصوصية"])
+@extends('layouts.app',['page_title'=>"شروط الاستخدام"])
 @section('content')
 <div class="col-12 p-0">
 	<div class=" p-0 container">
 		<div class="col-12 p-2 p-lg-3 row">
 			<div class="col-12 px-2 pt-5 pb-3">
 			    <div class="col-12 p-0 font-4">
-			        <span class="start-head"></span> سياسة الخصوصية
+			        <span class="start-head"></span> شروط الاستخدام
 			    </div>
 			  {{--   <div class="col-12 p-0 mt-1" style="opacity: .7;">
 			        معلومات عنا
 			    </div> --}}
+				asd
 			</div>
 			<div class="col-12 col-lg-8 p-2">
-				{!!$settings['privacy_page']!!}
+				{{-- {!!$settings['terms_page']!!} --}}
 			</div>
 		</div>
 	</div>

--- a/resources/views/front/pages/customPages/terms.blade.php
+++ b/resources/views/front/pages/customPages/terms.blade.php
@@ -10,7 +10,7 @@
 			  {{--   <div class="col-12 p-0 mt-1" style="opacity: .7;">
 			        معلومات عنا
 			    </div> --}}
-				asd
+				
 			</div>
 			<div class="col-12 col-lg-8 p-2">
 				{{-- {!!$settings['terms_page']!!} --}}


### PR DESCRIPTION
In this PR, a new feature is introduced to load custom views for specific pages in the system. Custom view files are placed in 'front.pages.customPages' path, and they are loaded based on the page's slug.

The 'page' function in the controller has been modified to perform a check for a custom view file corresponding to the given slug. If such a view file exists, the application will load the custom view. Otherwise, it falls back to the default 'front.pages.page' view.

A new directory 'customPages' has been created under 'front.pages', and custom view files have been added to it. These custom views allow for more flexibility in page design, especially for scenarios where certain pages require a unique layout different from the default one.

Please review the changes and provide your feedback.